### PR TITLE
added /etc/timezone to docker containers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
       - /lockss:/lockss
       - /var/log/lockss:/var/log/lockss
       - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     restart: always
     stop_grace_period: 1m
     healthcheck:


### PR DESCRIPTION
I have added /etc/timezone/ in compose.yaml so the LOCKSS Daemon will have the correct timezone 